### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,23 +1,11 @@
-Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License (CC BY-NC-ND 4.0)
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License (CC BY-NC-SA 4.0)
 
 Copyright 2025 Nicolas Stadler
 
-This work is licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License.
-You may not use this work for commercial purposes. You may not modify, adapt, or build upon this work in any way.
+This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
+You may not use this work for commercial purposes.
+You may remix, adapt, and build upon the work for non-commercial purposes only, and you must distribute your contributions under the same license as the original work.
 
-You are free to:
-- Share: Copy and redistribute the material in any medium, format, or platform, as long as you credit the original author.
+You must give appropriate credit to the original author, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the author endorses you or your use.
 
-Under the following terms:
-- Attribution: You must give appropriate credit to the original author, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the author endorses you or your use.
-
-- NonCommercial: You may not use the material for commercial purposes.
-
-- NoDerivatives: If you remix, transform, or build upon the material, you may not distribute the modified material. 
-
-You can view the full license here: https://creativecommons.org/licenses/by-nc-nd/4.0/
-
-For contributions:
-- By submitting a contribution to this project, you agree that your submission will be licensed under the same terms as this project.
-- Please ensure your contribution does not infringe on any intellectual property rights.
-
+You can view the full license here: https://creativecommons.org/licenses/by-nc-sa/4.0/

--- a/projects/pihub/components/breadcrumbs/breadcrumbs.component.html
+++ b/projects/pihub/components/breadcrumbs/breadcrumbs.component.html
@@ -1,4 +1,4 @@
-<svg class="home" (click)="onClick.emit(HomeId)" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+<svg class="home" (click)="crumbClick.emit(HomeId)" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
 	<path
 		d="M240-200h120v-200q0-17 11.5-28.5T400-440h160q17 0 28.5 11.5T600-400v200h120v-360L480-740 240-560v360Zm-80 0v-360q0-19 8.5-36t23.5-28l240-180q21-16 48-16t48 16l240 180q15 11 23.5 28t8.5 36v360q0 33-23.5 56.5T720-120H560q-17 0-28.5-11.5T520-160v-200h-80v200q0 17-11.5 28.5T400-120H240q-33 0-56.5-23.5T160-200Zm320-270Z"
 	/>
@@ -9,5 +9,5 @@
 			d="M480-361q-8 0-15-2.5t-13-8.5L268-556q-11-11-11-28t11-28q11-11 28-11t28 11l156 156 156-156q11-11 28-11t28 11q11 11 11 28t-11 28L508-372q-6 6-13 8.5t-15 2.5Z"
 		/>
 	</svg>
-	<p (click)="onClick.emit(crumbs().at($index)!.id)">{{ crumb.name }}</p>
+	<p (click)="crumbClick.emit(crumbs().at($index)!.id)">{{ crumb.name }}</p>
 }

--- a/projects/pihub/components/breadcrumbs/breadcrumbs.component.ts
+++ b/projects/pihub/components/breadcrumbs/breadcrumbs.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/
@@ -23,7 +23,7 @@ export class BreadcrumbsComponent {
 	 * The event emitter that fires if the user clicks on a crumb.
 	 * It emits the id of the clicked crumb.
 	 */
-	public readonly onClick = output<string>();
+	public readonly crumbClick = output<string>();
 
 	/**
 	 * The id of the `home` crumb.

--- a/projects/pihub/components/breadcrumbs/docs/ng-doc.page.ts
+++ b/projects/pihub/components/breadcrumbs/docs/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/breadcrumbs/index.ts
+++ b/projects/pihub/components/breadcrumbs/index.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/breadcrumbs/models/breadcrumb.ts
+++ b/projects/pihub/components/breadcrumbs/models/breadcrumb.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/button/button.component.ts
+++ b/projects/pihub/components/button/button.component.ts
@@ -1,10 +1,10 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/
-import { Component, HostBinding, input, output } from '@angular/core';
+import { Component, HostBinding, HostListener, input, output } from '@angular/core';
 
 @Component({
 	selector: 'pihub-button',
@@ -31,10 +31,17 @@ export class ButtonComponent {
 	/**
 	 * Output that emits when the button is clicked.
 	 */
-	public readonly click = output<void>();
+	public readonly buttonClick = output();
 
 	@HostBinding('class')
 	private get className() {
 		return [this.style(), this.disabled() ? 'disabled' : null].join(' ');
+	}
+
+	@HostListener('click')
+	private onClick() {
+		if (!this.disabled()) {
+			this.buttonClick.emit();
+		}
 	}
 }

--- a/projects/pihub/components/button/docs/ng-doc.page.ts
+++ b/projects/pihub/components/button/docs/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/button/index.ts
+++ b/projects/pihub/components/button/index.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/checkbox/checkbox.component.ts
+++ b/projects/pihub/components/checkbox/checkbox.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/
@@ -21,7 +21,7 @@ export class CheckboxComponent {
 	/**
 	 * The output that will fire if this checkbox is clicked.
 	 */
-	public readonly onClick = output<void>();
+	public readonly checkboxClicked = output();
 
 	/**
 	 * Set the class name depending on `checked`.
@@ -36,6 +36,6 @@ export class CheckboxComponent {
 	 */
 	@HostListener('click')
 	private onClickHandler(): void {
-		this.onClick.emit();
+		this.checkboxClicked.emit();
 	}
 }

--- a/projects/pihub/components/checkbox/docs/ng-doc.page.ts
+++ b/projects/pihub/components/checkbox/docs/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/data-grid/data-grid.component.ts
+++ b/projects/pihub/components/data-grid/data-grid.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/
@@ -62,7 +62,7 @@ export class DataGridComponent<Row extends DataGridItem> {
 	 * The amount of rows to be selected simultaneously.
 	 * Set to `0` to disable selection or set it to `-1` to allow selecting all rows.
 	 */
-	public readonly maxSelection = input<number | undefined>(-1);
+	public readonly maxSelection = input<number>(-1);
 
 	/**
 	 * Whether to show the column header.
@@ -172,7 +172,7 @@ export class DataGridComponent<Row extends DataGridItem> {
 		} else {
 			if (isAlreadySelected) {
 				newSelectedIds = this.selectedIds().filter((selectedId) => selectedId !== id);
-			} else if (this.maxSelection() === -1 || this.selectedIds().length < this.maxSelection()!) {
+			} else if (this.maxSelection() === -1 || this.selectedIds().length < this.maxSelection()) {
 				newSelectedIds = [...this.selectedIds(), id];
 			}
 		}

--- a/projects/pihub/components/data-grid/directives/column.directive.ts
+++ b/projects/pihub/components/data-grid/directives/column.directive.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/data-grid/directives/empty-state.directive.ts
+++ b/projects/pihub/components/data-grid/directives/empty-state.directive.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/data-grid/docs/data-grid-demo.component.ts
+++ b/projects/pihub/components/data-grid/docs/data-grid-demo.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/data-grid/docs/ng-doc.page.ts
+++ b/projects/pihub/components/data-grid/docs/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/data-grid/index.ts
+++ b/projects/pihub/components/data-grid/index.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/documentation/categories/ng-doc.category.ts
+++ b/projects/pihub/components/documentation/categories/ng-doc.category.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/documentation/ng-doc.api.ts
+++ b/projects/pihub/components/documentation/ng-doc.api.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/documentation/pages/style-guide/ng-doc.page.ts
+++ b/projects/pihub/components/documentation/pages/style-guide/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/components/tree-node.component.ts
+++ b/projects/pihub/components/tree/components/tree-node.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/directives/tree-node.directive.ts
+++ b/projects/pihub/components/tree/directives/tree-node.directive.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/docs/ng-doc.page.ts
+++ b/projects/pihub/components/tree/docs/ng-doc.page.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/docs/tree-demo.component.ts
+++ b/projects/pihub/components/tree/docs/tree-demo.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/index.ts
+++ b/projects/pihub/components/tree/index.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/models/tree-node.ts
+++ b/projects/pihub/components/tree/models/tree-node.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/components/tree/tree.component.ts
+++ b/projects/pihub/components/tree/tree.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/documentation/src/app/app.component.ts
+++ b/projects/pihub/documentation/src/app/app.component.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/
@@ -9,7 +9,7 @@ import { RouterOutlet } from '@angular/router';
 import { NgDocNavbarComponent, NgDocRootComponent, NgDocSidebarComponent } from '@ng-doc/app';
 
 @Component({
-	selector: 'app-root',
+	selector: 'pihub-doc-root',
 	templateUrl: './app.component.html',
 	styleUrl: './app.component.scss',
 	imports: [RouterOutlet, NgDocRootComponent, NgDocNavbarComponent, NgDocSidebarComponent],

--- a/projects/pihub/documentation/src/app/app.config.ts
+++ b/projects/pihub/documentation/src/app/app.config.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/documentation/src/app/app.routes.ts
+++ b/projects/pihub/documentation/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/documentation/src/index.html
+++ b/projects/pihub/documentation/src/index.html
@@ -8,6 +8,6 @@
 		<link rel="icon" href="assets/icons/pihub.svg" sizes="any" type="image/svg+xml" />
 	</head>
 	<body>
-		<app-root></app-root>
+		<pihub-doc-root></pihub-doc-root>
 	</body>
 </html>

--- a/projects/pihub/documentation/src/main.ts
+++ b/projects/pihub/documentation/src/main.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/projects/pihub/documentation/src/ng-doc.config.ts
+++ b/projects/pihub/documentation/src/ng-doc.config.ts
@@ -1,6 +1,6 @@
 /**-------------------------------------------------------------------------
  * Copyright (c) 2025 - Nicolas Stadler. All rights reserved.
- * Licensed under the MIT License. See the project root for more information.
+ * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.
  *
  * @author Nicolas Stadler
  *-------------------------------------------------------------------------*/

--- a/scripts/insert-copyright.ts
+++ b/scripts/insert-copyright.ts
@@ -10,7 +10,7 @@ for (const file of filesToProcess) {
 		continue;
 	}
 
-	insertDisclaimer(file);
+	void insertDisclaimer(file);
 }
 
 function getGitAuthor(): string {
@@ -27,7 +27,7 @@ function getDisclaimer(year: number, author: string): string {
 	return [
 		`/**-------------------------------------------------------------------------`,
 		` * Copyright (c) ${year} - ${author}. All rights reserved.`,
-		` * Licensed under the MIT License. See the project root for more information.`,
+		` * Licensed under the CC BY-NC-SA 4.0 License. See the project root for more information.`,
 		` *`,
 		` * @author ${author}`,
 		` *-------------------------------------------------------------------------*/\n`,
@@ -42,7 +42,7 @@ async function insertDisclaimer(filePath: string) {
 		return await writeFile(filePath, getDisclaimer(currentYear, author) + content);
 	}
 
-	const matches = content.match(/Copyright \(c\) (\d{4}) - (.*). All rights reserved./);
+	const matches = /Copyright \(c\) (\d{4}) - (.*). All rights reserved./.exec(content);
 
 	if (!matches) {
 		throw new Error(`Disclaimer already exists but no author or year could be matched in file ${filePath}`);


### PR DESCRIPTION
BREAKING CHANGE: update components outputs to not use `on` prefix and not collide with native events