### PR TITLE
Do not restrict icon size

### DIFF
--- a/projects/pihub/components/icon/icon.component.scss
+++ b/projects/pihub/components/icon/icon.component.scss
@@ -1,5 +1,10 @@
 :host {
-	display: block;
+	width: min-content;
+	height: min-content;
+
+	display: flex;
+	align-items: center;
+	justify-content: center;
 
 	> svg {
 		display: block;

--- a/projects/pihub/components/icon/icon.component.ts
+++ b/projects/pihub/components/icon/icon.component.ts
@@ -13,8 +13,6 @@ import { Icon } from './library';
 	templateUrl: './icon.component.html',
 	styleUrl: './icon.component.scss',
 	host: {
-		'[style.width.px]': 'width()',
-		'[style.height.px]': 'height()',
 		'(mouseenter)': 'onMouseEnter()',
 		'(mouseleave)': 'onMouseLeave()',
 	},


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR does and why these changes were made. -->
The `pihub-icon` currently has a `width` and `style` attribute which makes it impossible to style it further with e.g. paddings. 

## Change
<!-- Select the type of change you are making -->
- [ ] Major (breaking changes)
- [ ] Minor (new features or improvements that don’t break existing functionality)
- [x] Patch (bug fixes or small enhancements)

## Checklist
- [x] The PR title and description are clear and concise
- [x] Code is properly formatted according to project standards
- [x] Linting passes and is up-to-date
- [x] Documentation has been updated to reflect changes
- [x] The branch is up-to-date with the latest `develop` (or target branch)
- [x] The PR includes only relevant and necessary commits (rebased if needed)
- [x] CI checks pass successfully